### PR TITLE
provide plugins the config path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 
+dist: trusty
+
 language: java
 
 jdk:


### PR DESCRIPTION
This solves issue #28. This provides the plugins the config path (if they use a 2 parameter constructor). I have created a new branch to fix version 6.8.0.0, but actually this can be cherry-picked for earlier versions.