### PR TITLE
Update the link to the Maven repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ You can use Elasticsearch Cluster Runner as Embedded Elasticsearch in your appli
 
 ## Version
 
-[Versions in Maven Repository](http://central.maven.org/maven2/org/codelibs/elasticsearch-cluster-runner/)
+[Versions in Maven Repository](https://repo1.maven.org/maven2/org/codelibs/elasticsearch-cluster-runner/)
 
 ## Run on Your Application
 


### PR DESCRIPTION
Updates the link to the Maven repo to the correct location and uses
HTTPS.

Relates to #31 