### PR TITLE
Use OpenJDK to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 cache:
   directories:


### PR DESCRIPTION
Travis have changed their default build environment to Ubunti Xenial
which doesn't support Oracle's JDK anymore:
https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment

This makes this branch use OpenJDK, too.

Relates to: #31